### PR TITLE
fix(renderer): 支持选择 enum 字段名

### DIFF
--- a/packages/renderer/source/openapi/components/SchemaProperties.test.tsx
+++ b/packages/renderer/source/openapi/components/SchemaProperties.test.tsx
@@ -236,6 +236,26 @@ describe('SchemaProperties', () => {
     expect(markup).toContain('No request body properties match the current search.')
   })
 
+  it('allows selecting enum property names', () => {
+    const spec: OpenAPISpec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {},
+    }
+
+    const schema = {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string' },
+        size: { type: 'string', enum: ['720p', '1080p'] },
+      },
+    }
+
+    const markup = renderToStaticMarkup(<SchemaProperties title="Body properties" schema={schema} spec={spec} />)
+
+    expect(markup).toMatch(/<button[^>]*class="[^"]*select-text[^"]*"[^>]*>[\s\S]*?size/)
+  })
+
   it('renders nested properties as an indented tree outside prose styles', () => {
     const spec: OpenAPISpec = {
       openapi: '3.1.0',

--- a/packages/renderer/source/openapi/components/SchemaProperties.tsx
+++ b/packages/renderer/source/openapi/components/SchemaProperties.tsx
@@ -334,7 +334,7 @@ function SchemaNode(arg0: ExpandableSchemaNodeProps): ReactNode {
           aria-label={expanded ? t('openapi.collapse') : t('openapi.expand')}
           aria-expanded={expanded}
           onClick={() => setLocallyExpanded((value) => !value)}
-          className={clsx(rowClassName, 'cursor-pointer transition hover:bg-(--clarify-ui-hover-background) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--clarify-theme-tokens-colors-primary)')}
+          className={clsx(rowClassName, 'cursor-pointer select-text transition hover:bg-(--clarify-ui-hover-background) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--clarify-theme-tokens-colors-primary)')}
         >
           {content}
         </button>


### PR DESCRIPTION
## 变更说明

- 为 OpenAPI schema 中可展开的字段行启用文本选择
- 新增包含普通字符串与 enum 字段的回归测试

## 根因

enum 字段包含可展开的枚举值，因此字段行使用原生 `button` 渲染；Chrome 默认禁止选择按钮内文本，导致它与普通 `string` 字段的选择行为不一致。

## 用户影响

用户现在可以拖动选择并复制 enum 字段名，同时保留原有的枚举展开和收起交互。

## 验证

- `pnpm --filter @clarify-labs/renderer test`
- `pnpm --filter @clarify-labs/renderer typecheck`
- `pnpm --filter @clarify-labs/renderer lint`
- `pnpm --filter @clarify-labs/renderer build`

Closes #24
