### PR TITLE
fix(renderer): 拖选 enum 字段时不切换展开状态

### DIFF
--- a/packages/renderer/source/openapi/components/SchemaProperties.test.tsx
+++ b/packages/renderer/source/openapi/components/SchemaProperties.test.tsx
@@ -9,7 +9,7 @@ import type { OpenAPIOperation, OpenAPISpec } from '../lib/utils'
 
 import { EndpointRequest } from './EndpointSections'
 import { EndpointPath } from './OpenApiOperation'
-import { ParameterList, ResponseList, SchemaProperties } from './SchemaProperties'
+import { ParameterList, ResponseList, SchemaProperties, shouldToggleSchemaNode } from './SchemaProperties'
 
 describe('ParameterList', () => {
   it('renders nothing when there are no parameters', () => {
@@ -202,6 +202,12 @@ describe('schemaToType', () => {
 })
 
 describe('SchemaProperties', () => {
+  it('does not toggle for pointer clicks that finish a text selection', () => {
+    expect(shouldToggleSchemaNode(1, false)).toBe(false)
+    expect(shouldToggleSchemaNode(1, true)).toBe(true)
+    expect(shouldToggleSchemaNode(0, false)).toBe(true)
+  })
+
   it('fuzzy filters nested properties and keeps their parent path visible', () => {
     const spec = { openapi: '3.1.0', info: { title: 'Test API', version: '1.0.0' }, paths: {} }
     const schema = {

--- a/packages/renderer/source/openapi/components/SchemaProperties.tsx
+++ b/packages/renderer/source/openapi/components/SchemaProperties.tsx
@@ -247,6 +247,10 @@ function getRootSchemaNode(spec: OpenAPISpec, schema: unknown, defaultExpanded?:
 type SchemaNodeProps = { node: SchemaTreeNode; depth?: number; defaultExpanded?: boolean }
 type ExpandableSchemaNodeProps = SchemaNodeProps & { forceExpanded?: boolean }
 
+export function shouldToggleSchemaNode(clickDetail: number, selectionIsCollapsed: boolean | undefined): boolean {
+  return clickDetail === 0 || selectionIsCollapsed !== false
+}
+
 function EnumValueWithDescription(arg0: SchemaNodeProps): ReactNode {
   const { node } = arg0
 
@@ -333,7 +337,10 @@ function SchemaNode(arg0: ExpandableSchemaNodeProps): ReactNode {
           type="button"
           aria-label={expanded ? t('openapi.collapse') : t('openapi.expand')}
           aria-expanded={expanded}
-          onClick={() => setLocallyExpanded((value) => !value)}
+          onClick={(event) => {
+            if (!shouldToggleSchemaNode(event.detail, window.getSelection()?.isCollapsed)) return
+            setLocallyExpanded((value) => !value)
+          }}
           className={clsx(rowClassName, 'cursor-pointer select-text transition hover:bg-(--clarify-ui-hover-background) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--clarify-theme-tokens-colors-primary)')}
         >
           {content}


### PR DESCRIPTION
## 变更说明

- 拖动选择 enum 字段文本时，忽略随后触发的鼠标 click
- 保留普通鼠标单击和键盘 Enter / Space 的展开、收起行为
- 新增指针文本选择、普通点击和键盘点击的边界测试

## 背景

此 PR 依赖 #25。#25 允许选择 enum 字段文本后，拖动结束可能继续触发按钮 click，导致枚举项意外展开或收起。

## 用户影响

拖选 enum 字段名时不会改变枚举项的展开状态；正常点击与键盘操作保持不变。

## 验证

- `pnpm --filter @clarify-labs/renderer test`
- `pnpm --filter @clarify-labs/renderer typecheck`
- `pnpm --filter @clarify-labs/renderer lint`
- `pnpm --filter @clarify-labs/renderer build`

依赖：#25
